### PR TITLE
fix: cli dispatch case, rename brew->brews, direct gh clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,22 +42,22 @@ TODO: Add a short summary of this module.
 - `p6df::core::aliases::init()`
 - `p6df::core::aliases::module::init(module, dir)`
   - Args:
-    - module - 
-    - dir - 
+    - module -
+    - dir -
 
 ##### p6df-core/lib/cli.zsh
 
 - `p6df::core::cli::all(cmd, ...)`
   - Args:
-    - cmd - 
-    - ... - 
+    - cmd -
+    - ... -
 - `p6df::core::cli::all::run(dir, cmd)`
   - Args:
-    - dir - 
-    - cmd - 
+    - dir -
+    - cmd -
 - `p6df::core::cli::run(...)`
   - Args:
-    - ... - 
+    - ... -
 - `p6df::core::cli::usage([rc=0], [msg=])`
   - Synopsis: bin/p6df [-D|-d] [cmd]
   - Args:
@@ -68,15 +68,15 @@ TODO: Add a short summary of this module.
 
 - `p6df::core::completions::module::init(module, dir)`
   - Args:
-    - module - 
-    - dir - 
+    - module -
+    - dir -
 
 ##### p6df-core/lib/dev.zsh
 
 - `p6df::core::dev::dot(module, dep)`
   - Args:
-    - module - 
-    - dep - 
+    - module -
+    - dep -
 - `p6df::core::dev::graph([modules=$P6_DFZ_MODULES])`
   - Args:
     - OPTIONAL modules - [$P6_DFZ_MODULES]
@@ -85,7 +85,7 @@ TODO: Add a short summary of this module.
 
 - `p6df::core::file::load(file)`
   - Args:
-    - file - 
+    - file -
 
 ##### p6df-core/lib/homebrew.zsh
 
@@ -93,18 +93,18 @@ TODO: Add a short summary of this module.
 - `p6df::core::homebrew::casks::remove()`
 - `p6df::core::homebrew::cli::brew::install(...)`
   - Args:
-    - ... - 
+    - ... -
 - `p6df::core::homebrew::cli::brew::services::start(...)`
   - Args:
-    - ... - 
+    - ... -
 - `p6df::core::homebrew::cli::brew::services::stop(...)`
   - Args:
-    - ... - 
+    - ... -
 - `p6df::core::homebrew::cmd::brew(...)`
   - Args:
-    - ... - 
+    - ... -
 - `p6df::core::homebrew::init()`
-  - Synopsis: Warning: Using vim because no editor was set in the environment. This may change in the future, so we recommend setting EDITOR, or HOMEBREW_EDITOR to your preferred text editor.
+  - Synopsis: Warning: Using vim because no editor was set in the environment. This may change in the future, so we recommend setting EDITOR, or HOMEBREW_EDITOR to your preferred text editor. <!-- markdownlint-disable-line MD013 -->
 - `p6df::core::homebrew::install()`
 - `p6df::core::homebrew::nuke()`
 - `p6df::core::homebrew::remove()`
@@ -113,88 +113,88 @@ TODO: Add a short summary of this module.
 
 - `p6df::core::internal::branch(_module, dir)`
   - Args:
-    - _module - 
-    - dir - 
+    - _module -
+    - dir -
 - `p6df::core::internal::debug(msg)`
   - Args:
-    - msg - 
+    - msg -
 - `p6df::core::internal::diag(module, dir)`
   - Args:
-    - module - 
-    - dir - 
+    - module -
+    - dir -
 - `p6df::core::internal::diff(_module, dir)`
   - Args:
-    - _module - 
-    - dir - 
+    - _module -
+    - dir -
 - `p6df::core::internal::doc(_module, dir)`
   - Args:
-    - _module - 
-    - dir - 
+    - _module -
+    - dir -
 - `p6df::core::internal::fetch(module, dir)`
   - Args:
-    - module - 
-    - dir - 
+    - module -
+    - dir -
 - `p6df::core::internal::langs(module, dir)`
   - Args:
-    - module - 
-    - dir - 
+    - module -
+    - dir -
 - `p6df::core::internal::pull(_module, dir)`
   - Args:
-    - _module - 
-    - dir - 
+    - _module -
+    - dir -
 - `p6df::core::internal::push(_module, dir)`
   - Args:
-    - _module - 
-    - dir - 
+    - _module -
+    - dir -
 - `p6df::core::internal::recurse(module, dir, [callback=], ...)`
   - Args:
-    - module - 
-    - dir - 
+    - module -
+    - dir -
     - OPTIONAL callback - []
-    - ... - 
+    - ... -
 - `p6df::core::internal::recurse::deps::each(dir, callback, ...)`
   - Args:
-    - dir - 
-    - callback - 
-    - ... - 
+    - dir -
+    - callback -
+    - ... -
 - `p6df::core::internal::recurse::deps::run(module, func_deps, callback)`
   - Args:
-    - module - 
-    - func_deps - 
-    - callback - 
+    - module -
+    - func_deps -
+    - callback -
 - `p6df::core::internal::recurse::shortcircuit(module, dir, callback)`
   - Args:
-    - module - 
-    - dir - 
-    - callback - 
+    - module -
+    - dir -
+    - callback -
 - `p6df::core::internal::status(_module, dir)`
   - Args:
-    - _module - 
-    - dir - 
+    - _module -
+    - dir -
 - `p6df::core::internal::update(module, dir)`
   - Args:
-    - module - 
-    - dir - 
+    - module -
+    - dir -
 - `p6df::core::internal::vscodes(module, dir)`
   - Args:
-    - module - 
-    - dir - 
+    - module -
+    - dir -
 - `str func_callback = p6df::core::internal::recurse::callback(callback, prefix)`
   - Args:
-    - callback - 
-    - prefix - 
+    - callback -
+    - prefix -
 
 ##### p6df-core/lib/lang.zsh
 
 - `p6df::core::lang::mgr::init(dir, name)`
   - Args:
-    - dir - 
-    - name - 
+    - dir -
+    - name -
 - `str label:$ver = p6df::core::lang::prompt::lang(label, mgr_cmd, sys_cmd)`
   - Args:
-    - label - 
-    - mgr_cmd - 
-    - sys_cmd - 
+    - label -
+    - mgr_cmd -
+    - sys_cmd -
 
 ##### p6df-core/lib/main.zsh
 
@@ -206,87 +206,87 @@ TODO: Add a short summary of this module.
 
 - `p6df::core::module::add(short_module, _dir)`
   - Args:
-    - short_module - 
-    - _dir - 
+    - short_module -
+    - _dir -
 - `p6df::core::module::add::export()`
 - `p6df::core::module::add::lazy(short_module, _dir)`
   - Args:
-    - short_module - 
-    - _dir - 
+    - short_module -
+    - _dir -
 - `p6df::core::module::brews(module, dir)`
   - Args:
-    - module - 
-    - dir - 
+    - module -
+    - dir -
 - `p6df::core::module::diag(module, dir)`
   - Args:
-    - module - 
-    - dir - 
+    - module -
+    - dir -
 - `p6df::core::module::diff(module, dir)`
   - Args:
-    - module - 
-    - dir - 
+    - module -
+    - dir -
 - `p6df::core::module::doc(module, dir)`
   - Args:
-    - module - 
-    - dir - 
+    - module -
+    - dir -
 - `p6df::core::module::fetch(module, dir)`
   - Args:
-    - module - 
-    - dir - 
+    - module -
+    - dir -
 - `p6df::core::module::init(module, dir)`
   - Args:
-    - module - 
-    - dir - 
+    - module -
+    - dir -
 - `p6df::core::module::langs(module, dir)`
   - Args:
-    - module - 
-    - dir - 
+    - module -
+    - dir -
 - `p6df::core::module::parse(module, _dir)`
-  - Synopsis: Given a module as (organization/repository) return a hash/dict module="p6m7g8-dotfiles/p6df-js[:/path/to/dir]" dict = { repo:    p6df-js module:  js org:     p6m7g8-dotfiles path:    p6m7g8-dotfiles/p6df-js prefix:  p6df::modules::js [sub:     /path/to/dir] [plugin:  dir] version: master proto:   https host:    github.com }
+  - Synopsis: Given a module as (organization/repository) return a hash/dict module="p6m7g8-dotfiles/p6df-js[:/path/to/dir]" dict = { repo:    p6df-js module:  js org:     p6m7g8-dotfiles path:    p6m7g8-dotfiles/p6df-js prefix:  p6df::modules::js [sub:     /path/to/dir] [plugin:  dir] version: master proto:   https host:    github.com } <!-- markdownlint-disable-line MD013 -->
   - Args:
-    - module - 
-    - _dir - 
+    - module -
+    - _dir -
 - `p6df::core::module::pull(module, dir)`
   - Args:
-    - module - 
-    - dir - 
+    - module -
+    - dir -
 - `p6df::core::module::push(module, dir)`
   - Args:
-    - module - 
-    - dir - 
+    - module -
+    - dir -
 - `p6df::core::module::status(module, dir)`
   - Args:
-    - module - 
-    - dir - 
+    - module -
+    - dir -
 - `p6df::core::module::symlinks(module, dir)`
   - Args:
-    - module - 
-    - dir - 
+    - module -
+    - dir -
 - `p6df::core::module::sync(module, dir)`
   - Args:
-    - module - 
-    - dir - 
+    - module -
+    - dir -
 - `p6df::core::module::update(module, dir)`
   - Args:
-    - module - 
-    - dir - 
+    - module -
+    - dir -
 - `p6df::core::module::use(short_module, dir)`
   - Args:
-    - short_module - 
-    - dir - 
+    - short_module -
+    - dir -
 - `p6df::core::module::vscodes(module, dir)`
   - Args:
-    - module - 
-    - dir - 
+    - module -
+    - dir -
 - `str module = p6df::core::module::expand(short_module, _dir)`
   - Args:
-    - short_module - 
-    - _dir - 
+    - short_module -
+    - _dir -
 - `str str = p6df::core::module::env::name(module, _dir, callback)`
   - Args:
-    - module - 
-    - _dir - 
-    - callback - 
+    - module -
+    - _dir -
+    - callback -
 
 ##### p6df-core/lib/modules.zsh
 
@@ -296,7 +296,7 @@ TODO: Add a short summary of this module.
 - `p6df::core::modules::brews()`
 - `p6df::core::modules::foreach(callback)`
   - Args:
-    - callback - 
+    - callback -
 - `p6df::core::modules::init()`
 - `p6df::core::modules::langs()`
 - `p6df::core::modules::load()`
@@ -307,17 +307,17 @@ TODO: Add a short summary of this module.
 
 - `p6df::core::path::cd::if(dir)`
   - Args:
-    - dir - 
+    - dir -
 - `p6df::core::path::cd::init()`
 - `p6df::core::path::if(dir)`
   - Args:
-    - dir - 
+    - dir -
 - `p6df::core::path::init(dir)`
   - Args:
-    - dir - 
+    - dir -
 - `p6df::core::path::module::init(module)`
   - Args:
-    - module - 
+    - module -
 
 ##### p6df-core/lib/profile.zsh
 
@@ -328,22 +328,22 @@ TODO: Add a short summary of this module.
 - `p6df::core::prompt::init()`
 - `p6df::core::prompt::line::add::env(func)`
   - Args:
-    - func - 
+    - func -
 - `p6df::core::prompt::line::add::lang(func)`
   - Args:
-    - func - 
+    - func -
 - `p6df::core::prompt::line::add::mod(func)`
   - Args:
-    - func - 
+    - func -
 - `p6df::core::prompt::line::add::mod::bottom(func)`
   - Args:
-    - func - 
+    - func -
 - `p6df::core::prompt::module::init(module)`
   - Args:
-    - module - 
+    - module -
 - `str cnt = p6df::core::prompt::runtime::line(func)`
   - Args:
-    - func - 
+    - func -
 - `stream  = p6df::core::prompt::runtime()`
 - `stream  = p6df::core::prompt::runtime::lines()`
 

--- a/lib/cli.zsh
+++ b/lib/cli.zsh
@@ -146,7 +146,7 @@ p6df::core::cli::all() {
   fi
   for dir in $(p6_echo $modules); do
     p6_h1 "$dir"
-    p6_run_dir "$dir" "p6df::core::cli::all::run" "$dir" "$cmd"
+    p6_run_dir "$dir" "p6df::core::cli::all::run" "$dir" "$cmd" "$@"
   done
 }
 
@@ -164,9 +164,14 @@ p6df::core::cli::all() {
 p6df::core::cli::all::run() {
   local dir="$1"
   local cmd="$2"
+  shift 2
 
   local module=$(p6df::core::module::expand $(p6_uri_name "$dir"))
   p6_h2 "$module"
 
-  p6df::core::internal::recurse "$module" "$dir" "p6df::core::internal::${cmd}" "$@"
+  case $cmd in
+  help) p6df::core::cli::usage 0 "" ;;
+  p6df::*) p6_run_yield "$cmd" "$module" "$dir" "$@" ;;
+  *) p6df::core::module::${cmd} "$module" "$dir" "$@" ;;
+  esac
 }

--- a/lib/internal.zsh
+++ b/lib/internal.zsh
@@ -16,7 +16,7 @@ p6df::core::internal::fetch() {
     local dir="$2"
 
     if p6_dir_exists_NOT "$dir"; then
-        p6_run_write_cmd "gh repo clone $module $dir"
+        gh repo clone "$module" "$dir"
     fi
 }
 
@@ -158,6 +158,15 @@ p6df::core::internal::diag() {
     local dir="$2"
 
     p6_h5 "m=[$module], d=[$dir]"
+
+    p6_return_void
+}
+
+p6df::core::internal::brews() {
+    local module="$1"
+
+    echo "p6df::modules::$module::external::brews" >&2
+    p6_run_if "p6df::modules::$module::external::brews"
 
     p6_return_void
 }

--- a/lib/module.zsh
+++ b/lib/module.zsh
@@ -92,7 +92,7 @@ p6df::core::module::brews() {
    local module="$1"
    local dir="$2"
 
-   p6df::core::internal::recurse "$module" "$dir" "external::brew"
+   p6df::core::internal::recurse "$module" "$dir" "external::brews"
 
    p6_return_void
 }

--- a/lib/modules.zsh
+++ b/lib/modules.zsh
@@ -71,7 +71,7 @@ p6df::core::modules::init() {
 	p6df::user::modules
 	p6df::user::modules::init::pre
 
-	p6df::core::homebrew::init # HOMEBREW_PREFIX, m1 et al
+	p6df::core::homebrew::init
 
 	p6df::core::modules::load
 

--- a/t/cli.sh
+++ b/t/cli.sh
@@ -2,14 +2,23 @@
 
 main() {
 
-	. ../../p6common/lib/_bootstrap.sh
-	p6_bootstrap "../../p6common"
+	# Support CI (P6_DFZ_SRC_P6M7G8_DOTFILES_DIR=.) and local dev environments
+	local p6df_root
+	p6df_root="$(cd "${P6_DFZ_SRC_P6M7G8_DOTFILES_DIR:-.}" && pwd)"
+
+	local p6common_dir="$p6df_root/p6common"
+	. "$p6common_dir/lib/_bootstrap.sh"
+	p6_bootstrap "$p6common_dir"
+
+	# Set absolute path so test subshells that cd to temp dirs can still access lib files
+	if [ -z "${P6_DFZ_LIB_DIR:-}" ]; then
+		P6_DFZ_LIB_DIR="$p6df_root/lib"
+	fi
 
 	p6_test_setup "6"
 
-	# Source the p6df-core libraries
-	. $P6_DFZ_LIB_DIR/_bootstrap.zsh
-	p6df::core::_bootstrap
+	# Load the cli.zsh module under test directly (avoids network/module dependencies)
+	. "$P6_DFZ_LIB_DIR/cli.zsh"
 
 	######################################################################
 	# Test 1: cli.zsh has valid syntax
@@ -22,23 +31,19 @@ main() {
 	p6_test_finish
 
 	######################################################################
-	# Test 2: p6df::core::cli::all::run receives and uses cmd parameter
+	# Test 2: p6df::core::cli::all::run dispatches cmd via case statement
 	######################################################################
-	p6_test_start "p6df::core::cli::all::run receives cmd parameter"
+	p6_test_start "p6df::core::cli::all::run dispatches via case"
 	(
-		# Mock the internal recurse to capture what cmd was passed
 		p6_test_run "
-			p6df::core::internal::recurse() {
-				local callback=\$3
-				p6_echo \"\$callback\" | p6_filter_extract_after \"p6df::core::internal::\"
-			}
 			p6df::core::module::expand() { echo 'p6df-test'; }
 			p6_uri_name() { echo 'test'; }
 			p6_h2() { :; }
+			p6df::core::module::status() { return 0; }
 			mkdir -p testmod
 			p6df::core::cli::all::run testmod status
 		"
-		p6_test_assert_run_ok "cmd passed correctly" 0 "status"
+		p6_test_assert_run_rc "case dispatch rc" 0
 	)
 	p6_test_finish
 
@@ -49,10 +54,10 @@ main() {
 	(
 		p6_test_run "
 			set -u
-			p6df::core::internal::recurse() { return 0; }
 			p6df::core::module::expand() { echo 'p6df-test'; }
 			p6_uri_name() { echo 'test'; }
 			p6_h2() { :; }
+			p6df::core::module::status() { return 0; }
 			mkdir -p testdir
 			p6df::core::cli::all::run testdir status 2>&1
 		"
@@ -77,6 +82,23 @@ main() {
 	(
 		p6_test_run "p6_filter_row_select 'p6df::core::cli::all::run' < $P6_DFZ_LIB_DIR/cli.zsh | p6_filter_row_select '\"\$dir\" \"\$cmd\"' >/dev/null"
 		p6_test_assert_run_rc "cmd passed in call" 0
+	)
+	p6_test_finish
+
+	######################################################################
+	# Test 6: extra args are forwarded past dir and cmd to module function
+	######################################################################
+	p6_test_start "extra args forwarded past dir and cmd"
+	(
+		p6_test_run "
+			p6df::core::module::expand() { echo 'p6df-test'; }
+			p6_uri_name() { echo 'test'; }
+			p6_h2() { :; }
+			p6df::core::module::deploy() { return 0; }
+			mkdir -p testdir2
+			p6df::core::cli::all::run testdir2 deploy extra1 extra2
+		"
+		p6_test_assert_run_rc "extra args forwarded rc" 0
 	)
 	p6_test_finish
 


### PR DESCRIPTION
Refactor cli::all::run to use a case statement for dispatch. Rename external::brew to external::brews for consistency. Call gh repo clone directly instead of via p6_run_write_cmd. Add p6df::core::internal::brews() helper.