### PR TITLE
docs: document mcp and mcp::env hook API

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,16 @@
 
 ## Summary
 
-TODO: Add a short summary of this module.
+`p6df-core` is the framework foundation for the `p6df` dotfiles system. It provides:
+
+- Module lifecycle management: `init`, `deps`, `brews`, `langs`, `mcp`, `symlinks`, `vscodes`
+- Profile-based environment switching via `profile::on` / `profile::off`
+- MCP (Model Context Protocol) server installation and env config hooks
+- Shell prompt composition across modules
+- Alias and PATH initialization per module
+- CLI entry point (`bin/p6df`) for running any hook across one or all modules
+
+See [`doc/hook_api.md`](doc/hook_api.md) for the full hook contract and [`doc/flow.md`](doc/flow.md) for the initialization and CLI dispatch flow.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@
 - Alias and PATH initialization per module
 - CLI entry point (`bin/p6df`) for running any hook across one or all modules
 
-See [`doc/hook_api.md`](doc/hook_api.md) for the full hook contract and [`doc/flow.md`](doc/flow.md) for the initialization and CLI dispatch flow.
+See [`doc/hook_api.md`](doc/hook_api.md) for the full hook contract and
+[`doc/flow.md`](doc/flow.md) for the initialization and CLI dispatch flow.
 
 ## Contributing
 

--- a/doc/flow.md
+++ b/doc/flow.md
@@ -41,6 +41,10 @@ including module dependency recursion, callbacks, and the CLI execution path.
 bin/p6df
 └─ p6df::core::cli::run
    └─ p6df::core::module::$cmd
+
+Available $cmd values (dispatched via p6df::core::module::$cmd):
+  init, brews, langs, mcp, symlinks, vscodes, doc
+  fetch, update, pull, push, diff, status, diag, sync
 ```
 
 ```mermaid
@@ -73,5 +77,29 @@ flowchart TD
     D --> N[p6df::user::modules::init::post]
 
     CLI[bin/p6df] --> O[p6df::core::cli::run]
-    O --> P[p6df::core::module cmd]
+    O --> P[p6df::core::module::cmd]
+
+    P -->|cmd=mcp| MCP[p6df::modules::mod::mcp]
+    P -->|cmd=mcp::env| MCPENV[p6df::modules::mod::mcp::env]
+```
+
+---
+
+## MCP Hook Flow
+
+`mcp` and `mcp::env` are CLI-only hooks (not called during shell init).
+
+```text
+bin/p6df mcp [module]
+└─ p6df::core::module::mcp(module, dir)
+   └─ p6df::core::internal::recurse(module, dir, "mcp")
+      └─ p6df::modules::<mod>::mcp(module, dir)
+         ├─ install MCP server packages
+         └─ add server bin dirs to PATH
+
+bin/p6df mcp::env [module]
+└─ p6df::core::module::mcp::env(module, dir)
+   └─ p6df::core::internal::recurse(module, dir, "mcp::env")
+      └─ p6df::modules::<mod>::mcp::env(module, dir)
+         └─ set/unset auth tokens and config env vars
 ```

--- a/doc/hook_api.md
+++ b/doc/hook_api.md
@@ -6,6 +6,8 @@
   - [home::symlinks](#homesymlinks)
   - [external::brew](#externalbrew)
   - [langs(module, dir)](#langsmodule-dir)
+  - [mcp(module, dir)](#mcpmodule-dir)
+  - [mcp::env(module, dir)](#mcpenvmodule-dir)
   - [aliases::init](#aliasesinit)
   - [path::init](#pathinit)
   - [completions::init](#completionsinit)
@@ -57,6 +59,37 @@ Only `langs()` specific things should not work until `langs()` is run.
 
 Installs language managers. Also installs 3rd Party Language extensions like cran, uv, cpan, gems etc.
 Do not use brew for the extensions unless you must.
+
+## mcp(module, dir)
+
+- Presence: OPTIONAL
+
+Installs MCP (Model Context Protocol) servers required by this module and adds their executables to PATH.
+
+Use this hook to install MCP server packages (via `npm`, `pip`, `go install`, `brew`, etc.) and ensure
+their binaries are discoverable. This is the install-time counterpart to `mcp::env`.
+
+Called via `p6df mcp` (CLI) or `p6df::core::modules::mcp` (programmatic).
+
+Example things to do here:
+- `npm install -g @modelcontextprotocol/server-github`
+- `p6df::core::path::if "$HOME/.local/bin"`
+
+## mcp::env(module, dir)
+
+- Presence: OPTIONAL
+
+Sets or unsets environment variables required for MCP server authentication and configuration.
+Works in tandem with the profile system (`profile::on` / `profile::off`) so tokens and config
+are only active for the relevant profile.
+
+Called when switching profiles (`profile::on` / `profile::off`) or explicitly via `p6df mcp::env`.
+
+Variables set here should be unset in the corresponding `profile::off` implementation.
+
+Example variables managed here:
+- API tokens (`GITHUB_PERSONAL_ACCESS_TOKEN`, `DD_API_KEY`, `SLACK_BOT_TOKEN`, etc.)
+- Server config (`MCP_SERVER_URL`, account IDs, team IDs)
 
 ## aliases::init
 

--- a/doc/hook_api.md
+++ b/doc/hook_api.md
@@ -72,6 +72,7 @@ their binaries are discoverable. This is the install-time counterpart to `mcp::e
 Called via `p6df mcp` (CLI) or `p6df::core::modules::mcp` (programmatic).
 
 Example things to do here:
+
 - `npm install -g @modelcontextprotocol/server-github`
 - `p6df::core::path::if "$HOME/.local/bin"`
 
@@ -88,6 +89,7 @@ Called when switching profiles (`profile::on` / `profile::off`) or explicitly vi
 Variables set here should be unset in the corresponding `profile::off` implementation.
 
 Example variables managed here:
+
 - API tokens (`GITHUB_PERSONAL_ACCESS_TOKEN`, `DD_API_KEY`, `SLACK_BOT_TOKEN`, etc.)
 - Server config (`MCP_SERVER_URL`, account IDs, team IDs)
 


### PR DESCRIPTION
## Summary

- Add `mcp(module, dir)` and `mcp::env(module, dir)` entries to `doc/hook_api.md`
- Update `doc/flow.md` with MCP CLI dispatch path, available commands list, and MCP hook flow diagrams
- Fix `README.md` summary (replace TODO with actual description including links to doc files)

## Test plan

- [ ] Review `doc/hook_api.md` — mcp and mcp::env sections present and accurate
- [ ] Review `doc/flow.md` — CLI command list and MCP flow text/mermaid correct
- [ ] Review `README.md` — summary is descriptive and links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)