### PR TITLE
chore: replace raw echo/xargs with p6_msg/p6_error/p6_filter_join_words

### DIFF
--- a/lib/cli.zsh
+++ b/lib/cli.zsh
@@ -146,7 +146,7 @@ p6df::core::cli::all() {
     _org=$(p6_uri_name "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR")
     local _repos
     _repos=$(p6_dir_list "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR")
-    modules=$(for _r in $(p6_echo $_repos); do echo "$_org/$_r"; done | xargs)
+    modules=$(for _r in $(p6_echo $_repos); do p6_echo "$_org/$_r"; done | p6_filter_join_words)
   fi
   for dir in $(p6_echo $modules); do
     p6_h1 "$dir"

--- a/lib/file.zsh
+++ b/lib/file.zsh
@@ -12,10 +12,10 @@ p6df::core::file::load() {
   local file="$1"
 
   if [[ -r "$file" ]]; then
-    echo "p6df-core . $file" >>/tmp/p6/log.log
+    p6_msg "p6df-core . $file"
     . "$file"
   else
     true
-    echo "p6df::core::file::load($file): does not exist" >>/tmp/p6/log.log
+    p6_error "p6df::core::file::load($file): does not exist"
   fi
 }

--- a/lib/internal.zsh
+++ b/lib/internal.zsh
@@ -175,7 +175,7 @@ p6df::core::internal::diag() {
 p6df::core::internal::brews() {
     local module="$1"
 
-    echo "p6df::modules::$module::external::brews" >&2
+    p6_error "p6df::modules::$module::external::brews"
     p6_run_if "p6df::modules::$module::external::brews"
 
     p6_return_void

--- a/lib/module.zsh
+++ b/lib/module.zsh
@@ -335,7 +335,7 @@ p6df::core::module::add() {
   local module="$1"
   local _dir="$2"
 
-  local things=$(p6_word_unique "$P6_DFZ_MODULES $module" | xargs)
+  local things=$(p6_word_unique "$P6_DFZ_MODULES $module" | p6_filter_join_words)
 
   p6_env_export P6_DFZ_MODULES "$things"
 
@@ -373,7 +373,7 @@ p6df::core::module::add::lazy() {
 ######################################################################
 p6df::core::module::add::export() {
 
-  local things=$(p6_word_unique "$P6_DFZ_MODULES" | xargs)
+  local things=$(p6_word_unique "$P6_DFZ_MODULES" | p6_filter_join_words)
 
   p6_env_export P6_DFZ_MODULES "$things"
 


### PR DESCRIPTION
## Summary

- **Issue 13** (`lib/file.zsh`): Replace `echo >>log` with `p6_msg`/`p6_error` for consistent structured logging
- **Issue 14** (`lib/internal.zsh`): Replace `echo >&2` with `p6_error`
- **Issue 15** (`lib/cli.zsh`): Replace `| xargs` with `p6_filter_join_words` for module list assembly
- **Issue 16** (`lib/module.zsh`): Replace `| xargs` with `p6_filter_join_words` in `module::add` and `module::add::export`

## Test plan

- [ ] Module loading still logs to expected destinations
- [ ] `p6df a <cmd>` assembles module list correctly
- [ ] `p6df::core::module::add` and `p6df::core::module::add::export` correctly build the deduped module list

🤖 Generated with [Claude Code](https://claude.com/claude-code)