### PR TITLE
fix: revert p6_msg to bare echo in file::load (too early in load sequence)

### DIFF
--- a/lib/file.zsh
+++ b/lib/file.zsh
@@ -12,10 +12,10 @@ p6df::core::file::load() {
   local file="$1"
 
   if [[ -r "$file" ]]; then
-    p6_msg "p6df-core . $file"
+    echo "p6df-core . $file"
     . "$file"
   else
     true
-    p6_error "p6df::core::file::load($file): does not exist"
+    echo "p6df::core::file::load($file): does not exist" >&2
   fi
 }


### PR DESCRIPTION
## Summary
- Reverts `p6_msg` back to bare `echo` in `p6df::core::file::load()`
- `p6_msg` is not available when `file::load` runs during early shell init (before p6common is bootstrapped)
- Error observed: `p6df::core::file::load:4: command not found: p6_msg`

## Test plan
- [ ] Shell starts cleanly without `command not found: p6_msg` errors
- [ ] CI build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)