### PR TITLE
fix: redirect load output to /tmp/p6/log.log

### DIFF
--- a/lib/file.zsh
+++ b/lib/file.zsh
@@ -12,10 +12,10 @@ p6df::core::file::load() {
   local file="$1"
 
   if [[ -r "$file" ]]; then
-    echo "p6df-core . $file"
+    echo "p6df-core . $file" >>/tmp/p6/log.log
     . "$file"
   else
     true
-    echo "p6df::core::file::load($file): does not exist" >&2
+    echo "p6df::core::file::load($file): does not exist" >>/tmp/p6/log.log
   fi
 }


### PR DESCRIPTION
## Summary

- Redirects `echo` output in `p6df::core::file::load()` to `/tmp/p6/log.log` instead of stdout/stderr
- Reduces noise during shell initialization

## Test plan

- [ ] Shell loads without visible output clutter
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)