### PR TITLE
fix: add missing p6_return_void to fetch/update; fix hook_api.md

### DIFF
--- a/doc/hook_api.md
+++ b/doc/hook_api.md
@@ -30,12 +30,12 @@ Guidelines:
 
 Some files may require token substitution for secrets.
 
-## external::brew
+## external::brews
 
 - Presence: OPTIONAL
 - Purpose: install external packages.
 
-Choose intentionally between `clones()`, `deps()`, and `external::brew`.
+Choose intentionally between `clones()`, `deps()`, and `external::brews`.
 Install prerequisites needed by `langs()`. Only language-specific setup should wait for `langs()`.
 
 ## langs(module, dir)

--- a/lib/internal.zsh
+++ b/lib/internal.zsh
@@ -18,6 +18,8 @@ p6df::core::internal::fetch() {
     if p6_dir_exists_NOT "$dir"; then
         gh repo clone "$module" "$dir"
     fi
+
+    p6_return_void
 }
 
 ######################################################################
@@ -40,6 +42,8 @@ p6df::core::internal::update() {
     else
         p6df::core::internal::pull "$module" "$dir"
     fi
+
+    p6_return_void
 }
 
 ######################################################################


### PR DESCRIPTION
## Summary
- `p6df::core::internal::fetch()` and `update()` were missing `p6_return_void`
- `hook_api.md` documented `external::brew` (singular) instead of `external::brews` (plural)

## Test plan
- [ ] Verify framework module dispatch works for `external::brews`