### PR TITLE
chore(core): tighten .gitignore from share/ to share/.cache/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-share/
+share/.cache/


### PR DESCRIPTION
## What
Replace overly broad `share/` gitignore with `share/.cache/`.

## Why
The broad `share/` was hiding all share/ content from git. Only the .cache/ subdirectory (runtime cache) should be excluded.

## Test plan
- `git status` shows intentional share/ files as trackable

## Dependencies
None