### PR TITLE
fix(core): add env/cdpath/fpath/langmgr module hooks, profile mod/on/off dispatch, bootstrap module init, and expand prompt module parse

### DIFF
--- a/doc/AGENTS.md
+++ b/doc/AGENTS.md
@@ -35,7 +35,7 @@ Important sibling repos:
 ## Preferred CLIs
 
 - `bin/p6df` for lifecycle/recursion:
-  `status`, `diff`, `pull`, `push`, `langs`, `brews`, `vscodes`, `symlinks`, `diag`, `fetch`, `update`
+  `status`, `diff`, `pull`, `push`, `langs`, `brews`, `mcp`, `vscodes`, `symlinks`, `diag`, `fetch`, `update`
 - `../p6df/bin/p6install` for bootstrap only
 - `../p6common/bin/p6ctl` for shared control behavior
 

--- a/doc/flow.md
+++ b/doc/flow.md
@@ -13,19 +13,37 @@ This doc is the quick reference for boot flow and CLI dispatch in `p6df-core`.
 .zshrc
 └─ p6df::core::init
    └─ p6df::core::main::init
+      ├─ p6df::core::timing::init
+      ├─ p6df::core::main::self::init
       ├─ p6df::core::user::init
       │  └─ load "$HOME/.zsh-me..."
+      ├─ p6df::core::path::init          # seed $PATH
+      ├─ p6df::core::path::cd::init      # seed $cdpath
+      ├─ p6df::core::aliases::init       # core aliases
+      ├─ p6df::core::prompt::init
       └─ p6df::core::modules::init
          ├─ p6df::user::modules
-         ├─ p6df::user::modules::init::pre $P6_AWS_ORG
-         ├─ p6df::core::modules::foreach "p6df::core::module::init" $P6_DFZ_MODULES
-         │  └─ p6df::core::module::init "$module"
-         │     ├─ return if already loaded
-         │     ├─ run deps hook, recurse through dependency chain
-         │     └─ run init hook
-         ├─ p6df::core::prompt::module::init
-         ├─ p6df::core::aliases::module::init
+         ├─ p6df::user::modules::init::pre
+         ├─ p6df::core::homebrew::init
+         ├─ p6df::core::modules::load
+         │  └─ p6df::core::modules::foreach "p6df::core::module::init" $P6_DFZ_MODULES
+         │     └─ p6df::core::module::init(module, dir)
+         │        ├─ p6df::core::bootstrap::module::init   → p6_bootstrap lib/
+         │        ├─ p6df::core::internal::recurse
+         │        │  ├─ shortcircuit (once per module per callback)
+         │        │  ├─ p6_file_load init.zsh
+         │        │  ├─ deps::each → internal::recurse (recursive)
+         │        │  └─ ::init hook
+         │        ├─ p6df::core::env::module::init         → env::init
+         │        ├─ p6df::core::path::module::init        → path::init
+         │        ├─ p6df::core::cdpath::module::init      → cdpath::init
+         │        ├─ p6df::core::fpath::module::init       → fpath::init
+         │        ├─ p6df::core::completions::module::init → completions::init
+         │        ├─ p6df::core::aliases::module::init     → aliases::init
+         │        ├─ p6df::core::langmgr::module::init     → langmgr::init
+         │        └─ p6df::core::prompt::module::init      → prompt::init, prompt::lang, prompt::env, profile::mod, prompt::mod::bottom
          └─ p6df::user::modules::init::post
+      └─ p6df::core::theme::init
 ```
 
 ## CLI Dispatch Flow
@@ -56,3 +74,16 @@ bin/p6df mcp [module]
 
 MCP auth/env config is handled in downstream modules via `profile::on` and `profile::off` hooks
 (for example `p6df-1password`, `p6df-claude`), not in `p6df-core`.
+
+## Profile Hook Flow
+
+```text
+<selector script>
+├─ p6df::core::profile::module::on(module, profile, code)
+│  ├─ dispatches to <mod>::profile::on if defined
+│  └─ default: p6_run_code "$code"            # export credential env vars
+│
+└─ p6df::core::profile::module::off(module, code)
+   ├─ dispatches to <mod>::profile::off if defined
+   └─ default: p6_env_unset_from_code "$code" # unset credential env vars
+```

--- a/doc/hook_api.md
+++ b/doc/hook_api.md
@@ -77,6 +77,30 @@ Aliases should be namespaced and should call functions (not shell one-liners).
 - Presence: OPTIONAL
 - Purpose: add module path entries.
 
+## cdpath::init
+
+- Presence: OPTIONAL
+- Purpose: add module entries to `cdpath` (the directory search path used by `cd`).
+
+Use `p6df::core::path::cd::if <dir>` to conditionally append a directory.
+
+## fpath::init
+
+- Presence: OPTIONAL
+- Purpose: add module entries to `fpath` (the zsh function autoload search path).
+
+Use this hook to expose autoloadable functions before `compinit` runs.
+
+## env::init
+
+- Presence: OPTIONAL
+- Purpose: export module-specific environment variables.
+
+Called during module initialisation to set variables that the module or its
+tools rely on (API keys with safe defaults, feature flags, paths, etc.).
+Prefer `p6_env_export KEY "${KEY:-default}"` so an already-exported value is
+not overwritten.
+
 ## completions::init
 
 - Presence: OPTIONAL
@@ -103,9 +127,63 @@ Return valid JSON for this module and its extensions.
 
 This hook is setup-only; it does not render prompt output.
 
-## prompt::mod
+## profile::on
+
+- Presence: OPTIONAL
+- Purpose: activate a named profile for the module.
+
+Signature: `profile::on(profile, code)`
+
+- `profile` — an arbitrary name for the active context (e.g. `work`, `personal`).
+- `code` — a shell code block (typically a series of `export KEY=value` statements)
+  that is evaluated via `p6_run_code` to inject secrets or credentials.
+
+Implementations typically:
+1. Evaluate `$code` to export credential env vars.
+
+MCP auth tokens and credential env vars are managed here (or in downstream
+modules such as `p6df-1password`), not in `p6df-core`.
+
+The default implementation (used when no module-specific hook exists) calls
+`p6df::core::profile::default::on "$code"` which simply runs `p6_run_code "$code"`.
+
+## profile::off
+
+- Presence: OPTIONAL
+- Purpose: deactivate the module's active profile.
+
+Signature: `profile::off(code)`
+
+- `code` — the same shell code block previously passed to `profile::on`.
+
+Implementations typically:
+1. Call `p6_env_unset_from_code "$code"` to unset all vars exported by that block.
+
+The default implementation (used when no module-specific hook exists) calls
+`p6df::core::profile::default::off "$code"` which simply runs `p6_env_unset_from_code "$code"`.
+
+## profile::mod
 
 - Presence: OPTIONAL
 - Purpose: render the module's prompt segment.
 
-Use this hook for visible prompt content.
+This is the canonical mod-line prompt hook. It replaces `prompt::mod`.
+
+Signature: `profile::mod()` — no arguments.
+
+Return a single string. Two formats are supported:
+
+1. **Pre-formatted string** — returned as-is in the prompt.
+2. **Label + `$VAR` tokens** — `label $VAR1 $VAR2 ...`; the runtime expands each
+   variable reference and formats the result as `label:\t\t  val1 val2`.
+
+Use format 2 when the displayed values come from environment variables set by
+`profile::on`, so the prompt always reflects the live value.
+
+## prompt::mod::bottom
+
+- Presence: OPTIONAL
+- Purpose: render a module's prompt segment on the bottom prompt line.
+
+Same return format as `profile::mod`. Use for lower-priority or wide content
+that should appear below the main prompt line.

--- a/doc/hook_api.md
+++ b/doc/hook_api.md
@@ -139,6 +139,7 @@ Signature: `profile::on(profile, code)`
   that is evaluated via `p6_run_code` to inject secrets or credentials.
 
 Implementations typically:
+
 1. Evaluate `$code` to export credential env vars.
 
 MCP auth tokens and credential env vars are managed here (or in downstream
@@ -157,6 +158,7 @@ Signature: `profile::off(code)`
 - `code` — the same shell code block previously passed to `profile::on`.
 
 Implementations typically:
+
 1. Call `p6_env_unset_from_code "$code"` to unset all vars exported by that block.
 
 The default implementation (used when no module-specific hook exists) calls

--- a/lib/aliases.zsh
+++ b/lib/aliases.zsh
@@ -46,3 +46,4 @@ p6df::core::aliases::module::init() {
 
   p6_return_void
 }
+

--- a/lib/cli.zsh
+++ b/lib/cli.zsh
@@ -129,7 +129,7 @@ p6df::core::cli::run() {
 #	cmd -
 #	... - 
 #
-#  Environment:	 P6_DFZ_MODULES P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
+#  Environment:	 P6_DFZ_MODULES P6_DFZ_SRC_DIR P6_DFZ_SRC_P6M7G8_DOTFILES_DIR _
 #>
 ######################################################################
 p6df::core::cli::all() {

--- a/lib/env.zsh
+++ b/lib/env.zsh
@@ -3,7 +3,7 @@
 ######################################################################
 #<
 #
-# Function: p6df::core::completions::module::init(module, dir)
+# Function: p6df::core::env::module::init(module, dir)
 #
 #  Args:
 #	module -
@@ -11,17 +11,17 @@
 #
 #>
 ######################################################################
-p6df::core::completions::module::init() {
+p6df::core::env::module::init() {
   local module="$1"
   local dir="$2"
 
   # %repo
   p6df::core::module::parse "$module"
-  local completions_func=$repo[completion]
+  local env_func=$repo[env_init]
   unset repo
 
-  if type -f "$completions_func" >/dev/null 2>&1; then
-    p6_run_yield "$completions_func $module $dir"
+  if type -f "$env_func" >/dev/null 2>&1; then
+    p6_run_yield "$env_func $module $dir"
   fi
 
   p6_return_void

--- a/lib/lang.zsh
+++ b/lib/lang.zsh
@@ -1,6 +1,33 @@
 ######################################################################
 #<
 #
+# Function: p6df::core::langmgr::module::init(module, dir)
+#
+#  Args:
+#	module -
+#	dir -
+#
+#>
+######################################################################
+p6df::core::langmgr::module::init() {
+  local module="$1"
+  local dir="$2"
+
+  # %repo
+  p6df::core::module::parse "$module"
+  local langmgr_func=$repo[langmgr_init]
+  unset repo
+
+  if type -f "$langmgr_func" >/dev/null 2>&1; then
+    p6_run_yield "$langmgr_func $module $dir"
+  fi
+
+  p6_return_void
+}
+
+######################################################################
+#<
+#
 # Function: p6df::core::lang::mgr::init(dir, name)
 #
 #  Args:

--- a/lib/module.zsh
+++ b/lib/module.zsh
@@ -26,13 +26,19 @@ p6df::core::module::init() {
   local module="$1"
   local dir="$2"
 
+  p6df::core::bootstrap::module::init "$module" "$dir"      # Bootstrap
+
   p6df::core::internal::recurse "$module" "$dir" "init"
 
   # After 'Tail-recursion' also run api hooks
-  p6df::core::prompt::module::init "$module" "$dir"         # Prompt
-  p6df::core::aliases::module::init "$module" "$dir"        # Aliases
+  p6df::core::env::module::init "$module" "$dir"            # Env
   p6df::core::path::module::init "$module" "$dir"           # Path
+  p6df::core::cdpath::module::init "$module" "$dir"         # CDPath
+  p6df::core::fpath::module::init "$module" "$dir"          # FPath
   p6df::core::completions::module::init "$module" "$dir"    # Completions
+  p6df::core::aliases::module::init "$module" "$dir"        # Aliases
+  p6df::core::langmgr::module::init "$module" "$dir"        # LangMgr
+  p6df::core::prompt::module::init "$module" "$dir"         # Prompt
 
   p6_return_void
 }
@@ -442,12 +448,24 @@ p6df::core::module::parse() {
   repo[module]=${repo[repo]##p6df-}                   # p6df-(repo)
 #  repo[module]=${repo[module]##p6}                   # p6(repo)
   repo[prefix]=p6df::modules::$repo[module]           # p6df::modules::(repo) without p6df-
-  repo[prompt_mod]=$repo[prefix]::prompt::mod         # prompt module function
+  repo[prompt_mod_bottom]=$repo[prefix]::prompt::mod::bottom # prompt mod bottom function
+  repo[prompt_runtime]=$repo[prefix]::prompt::runtime  # prompt runtime function
+  repo[prompt_context]=$repo[prefix]::prompt::context  # prompt context function
+  repo[prompt_system]=$repo[prefix]::prompt::system    # prompt system function
   repo[prompt_env]=$repo[prefix]::prompt::env         # prompt env function
   repo[prompt_lang]=$repo[prefix]::prompt::lang       # prompt lang function
+  repo[env_init]=$repo[prefix]::env::init              # env function
   repo[alias]=$repo[prefix]::aliases::init            # alias function
+  repo[skills_init]=$repo[prefix]::skills::init       # skills function
   repo[path_init]=$repo[prefix]::path::init           # path function
+  repo[cdpath_init]=$repo[prefix]::cdpath::init       # cdpath function
+  repo[fpath_init]=$repo[prefix]::fpath::init         # fpath function
   repo[completion]=$repo[prefix]::completions::init   # completion function
+  repo[langmgr_init]=$repo[prefix]::langmgr::init     # langmgr function
+  repo[prompt_init]=$repo[prefix]::prompt::init        # prompt init function
+  repo[profile_on]=$repo[prefix]::profile::on          # profile on function
+  repo[profile_off]=$repo[prefix]::profile::off        # profile off function
+  repo[profile_mod]=$repo[prefix]::profile::mod        # profile mod function
 
   repo[sub]=${module##*:}                    # subdir file path : sep
   repo[plugin]=${repo[sub]##*/}              # subdir plugin up to first /
@@ -495,4 +513,32 @@ p6df::core::module::env::name() {
   local str=$(p6_string_sanitize_identifier "${module}-${callback}")
 
   p6_return_str "$str"
+}
+
+######################################################################
+#<
+#
+# Function: p6df::core::bootstrap::module::init(module, _dir)
+#
+#  Args:
+#	module -
+#	_dir -
+#
+#  Environment:	 P6_DFZ_SRC_DIR
+#>
+######################################################################
+p6df::core::bootstrap::module::init() {
+  local module="$1"
+  local _dir="$2"
+
+  # %repo
+  p6df::core::module::parse "$module"
+  local module_dir="$P6_DFZ_SRC_DIR/$repo[path]"
+  unset repo
+
+  if [[ -d "$module_dir/lib" ]]; then
+    p6_bootstrap "$module_dir"
+  fi
+
+  p6_return_void
 }

--- a/lib/path.zsh
+++ b/lib/path.zsh
@@ -64,15 +64,17 @@ p6df::core::path::init() {
 ######################################################################
 #<
 #
-# Function: p6df::core::path::module::init(module)
+# Function: p6df::core::path::module::init(module, dir)
 #
 #  Args:
 #	module -
+#	dir -
 #
 #>
 ######################################################################
 p6df::core::path::module::init() {
   local module="$1"
+  local dir="$2"
 
   # %repo
   p6df::core::module::parse "$module"
@@ -80,7 +82,7 @@ p6df::core::path::module::init() {
   unset repo
 
   if type -f "$path_func" >/dev/null 2>&1; then
-    p6_run_yield "$path_func"
+    p6_run_yield "$path_func $module $dir"
   fi
 
   p6_return_void
@@ -107,4 +109,58 @@ p6df::core::path::cd::init() {
   p6df::core::path::cd::if $P6_DFZ_SRC_FOCUSED_DIR
   p6df::core::path::cd::if $P6_DFZ_SRC_WORK_DIR
   p6df::core::path::cd::if $P6_DFZ_SRC_WORK_ARKESTRO_DIR
+}
+
+######################################################################
+#<
+#
+# Function: p6df::core::cdpath::module::init(module, dir)
+#
+#  Args:
+#	module -
+#	dir -
+#
+#>
+######################################################################
+p6df::core::cdpath::module::init() {
+  local module="$1"
+  local dir="$2"
+
+  # %repo
+  p6df::core::module::parse "$module"
+  local cdpath_func=$repo[cdpath_init]
+  unset repo
+
+  if type -f "$cdpath_func" >/dev/null 2>&1; then
+    p6_run_yield "$cdpath_func $module $dir"
+  fi
+
+  p6_return_void
+}
+
+######################################################################
+#<
+#
+# Function: p6df::core::fpath::module::init(module, dir)
+#
+#  Args:
+#	module -
+#	dir -
+#
+#>
+######################################################################
+p6df::core::fpath::module::init() {
+  local module="$1"
+  local dir="$2"
+
+  # %repo
+  p6df::core::module::parse "$module"
+  local fpath_func=$repo[fpath_init]
+  unset repo
+
+  if type -f "$fpath_func" >/dev/null 2>&1; then
+    p6_run_yield "$fpath_func $module $dir"
+  fi
+
+  p6_return_void
 }

--- a/lib/profile.zsh
+++ b/lib/profile.zsh
@@ -1,20 +1,204 @@
 # shellcheck shell=bash
 
+
 ######################################################################
 #<
 #
-# Function: str str = p6df::core::profile::prompt::mod()
+# Function: str str = p6df::core::profile::default::mod([label=], ...)
+#
+#  Args:
+#	OPTIONAL label - []
+#	... - 
 #
 #  Returns:
 #	str - str
 #
-#  Environment:	 P6_DFZ_PROFILE
 #>
 ######################################################################
-p6df::core::profile::prompt::mod() {
+p6df::core::profile::secret::label() {
+  local var_name="${1#\$}"       # strip leading $
+  var_name="${var_name#\{}"      # strip leading {
+  var_name="${var_name%\}}"      # strip trailing }
+  var_name="${var_name:u}"       # uppercase
+
+  case "$var_name" in
+    *_TOKEN*|*_SECRET*|*_PASSWORD*|*_PASSWD*|*_PASS|*_API_KEY*|*_AUTH_TOKEN*|*_BEARER*|*_PRIVATE_KEY*|*_ACCESS_KEY*)
+      p6_return_str "$var_name" ;;
+    *_SDK*)
+      p6_return_str "[sdk]" ;;
+    *)
+      p6_return_void ;;
+  esac
+}
+
+######################################################################
+#<
+#
+# Function: str str = p6df::core::profile::default::mod([label=], ...)
+#
+#  Args:
+#	OPTIONAL label - []
+#	... -
+#
+#  Returns:
+#	str - str
+#
+#>
+######################################################################
+p6df::core::profile::default::mod() {
+  local label="${1:-}"
+  shift
+
+  local -a values
+  local fmt
+  for fmt in "$@"; do
+    local value="${(e)fmt}"
+    if p6_string_blank_NOT "$value"; then
+      local redacted=$(p6df::core::profile::secret::label "$fmt")
+      if p6_string_blank_NOT "$redacted"; then
+        values+=("$redacted")
+      else
+        values+=("$value")
+      fi
+    fi
+  done
 
   local str
-  str="_p6_dfz_profile:  $P6_DFZ_PROFILE"
+  if [[ ${#values} -gt 0 ]]; then
+    str="$(p6_string_space_pad "${label}:" 16)${(j: :)values}"
+  fi
 
   p6_return_str "$str"
+}
+
+######################################################################
+#<
+#
+# Function: str str = p6df::core::profile::module::mod(module)
+#
+#  Args:
+#	module -
+#
+#  Returns:
+#	str - str
+#
+#>
+######################################################################
+p6df::core::profile::module::mod() {
+  local module="$1"
+
+  # %repo
+  p6df::core::module::parse "$module"
+  local profile_mod_func=$repo[profile_mod]
+  unset repo
+
+  local label
+  local -a fmts
+  if type -f "$profile_mod_func" >/dev/null 2>&1; then
+    local -a parts
+    parts=("${(z)$("$profile_mod_func")}")
+    label="${parts[1]}"
+    fmts=("${parts[2,-1]}")
+  fi
+
+  local str
+  str=$(p6df::core::profile::default::mod "$label" "${fmts[@]}")
+
+  p6_return_str "$str"
+}
+
+######################################################################
+#<
+#
+# Function: p6df::core::profile::default::on(code)
+#
+#  Args:
+#	code -
+#
+#>
+######################################################################
+p6df::core::profile::default::on() {
+  local code="$1"
+
+  p6_run_code "$code"
+
+  p6_return_void
+}
+
+######################################################################
+#<
+#
+# Function: p6df::core::profile::default::off(code)
+#
+#  Args:
+#	code -
+#
+#>
+######################################################################
+p6df::core::profile::default::off() {
+  local code="$1"
+
+  p6_env_unset_from_code "$code"
+
+  p6_return_void
+}
+
+######################################################################
+#<
+#
+# Function: p6df::core::profile::module::on(module, profile, code)
+#
+#  Args:
+#	module -
+#	profile -
+#	code -
+#
+#>
+######################################################################
+p6df::core::profile::module::on() {
+  local module="$1"
+  local profile="$2"
+  local code="$3"
+
+  # %repo
+  p6df::core::module::parse "$module"
+  local profile_on_func=$repo[profile_on]
+  unset repo
+
+  if type -f "$profile_on_func" >/dev/null 2>&1; then
+    "$profile_on_func" "$profile" "$code"
+  else
+    p6df::core::profile::default::on "$code"
+  fi
+
+  p6_return_void
+}
+
+######################################################################
+#<
+#
+# Function: p6df::core::profile::module::off(module, code)
+#
+#  Args:
+#	module -
+#	code -
+#
+#>
+######################################################################
+p6df::core::profile::module::off() {
+  local module="$1"
+  local code="$2"
+
+  # %repo
+  p6df::core::module::parse "$module"
+  local profile_off_func=$repo[profile_off]
+  unset repo
+
+  if type -f "$profile_off_func" >/dev/null 2>&1; then
+    "$profile_off_func" "$code"
+  else
+    p6df::core::profile::default::off "$code"
+  fi
+
+  p6_return_void
 }

--- a/lib/prompt.zsh
+++ b/lib/prompt.zsh
@@ -3,12 +3,15 @@
 #
 # Function: p6df::core::prompt::init()
 #
-#  Environment:	 P6_DFZ_PROMPT_ENV_LINES P6_DFZ_PROMPT_LANG_LINES P6_DFZ_PROMPT_MOD_BOTTOM_LINES P6_DFZ_PROMPT_MOD_LINES PROMPT
+#  Environment:	 P6_DFZ_PROMPT_CONTEXT_LINES P6_DFZ_PROMPT_ENV_LINES P6_DFZ_PROMPT_LANG_LINES P6_DFZ_PROMPT_MOD_BOTTOM_LINES P6_DFZ_PROMPT_MOD_LINES P6_DFZ_PROMPT_RUNTIME_LINES P6_DFZ_PROMPT_SYSTEM_LINES PROMPT
 #>
 ######################################################################
 p6df::core::prompt::init() {
 
   p6_env_export P6_DFZ_PROMPT_LANG_LINES ""
+  p6_env_export P6_DFZ_PROMPT_RUNTIME_LINES ""
+  p6_env_export P6_DFZ_PROMPT_CONTEXT_LINES ""
+  p6_env_export P6_DFZ_PROMPT_SYSTEM_LINES ""
   p6_env_export P6_DFZ_PROMPT_ENV_LINES ""
   p6_env_export P6_DFZ_PROMPT_MOD_LINES ""
   p6_env_export P6_DFZ_PROMPT_MOD_BOTTOM_LINES ""
@@ -30,7 +33,7 @@ $PROMPT
 # Function: stream  = p6df::core::prompt::runtime()
 #
 #  Returns:
-#	stream - 
+#	stream -
 #
 #>
 ######################################################################
@@ -50,7 +53,7 @@ p6df::core::prompt::runtime() {
 # Function: stream  = p6df::core::prompt::runtime::lines()
 #
 #  Returns:
-#	stream - 
+#	stream -
 #
 #  Environment:	 EPOCHREALTIME P6_DFZ_PROMPT_IN_VSCODE _
 #>
@@ -73,23 +76,42 @@ p6df::core::prompt::runtime::lines() {
   done
 
   if p6_string_blank_NOT "$langs_line"; then
-     p6_echo "langs:\t\t  ${langs_line}"
+     p6_echo "$(p6_string_space_pad "langs:" 16)${langs_line}"
   fi
 
-  local -a _other_lines
   if p6_string_blank "$P6_DFZ_PROMPT_IN_VSCODE"; then
-    _other_lines=(
-      ${=P6_DFZ_PROMPT_ENV_LINES}
-      ${=P6_DFZ_PROMPT_MOD_LINES}
-      ${=P6_DFZ_PROMPT_MOD_BOTTOM_LINES}
-    )
-  else
-    _other_lines=(${=P6_DFZ_PROMPT_MOD_BOTTOM_LINES})
+
+    if p6_string_blank "$P6_DFZ_RUNTIME_DISABLE"; then
+      local -a _runtime_lines=( ${=P6_DFZ_PROMPT_RUNTIME_LINES} )
+      for lf in $_runtime_lines; do p6df::core::prompt::runtime::line "$lf"; done
+    fi
+
+    if p6_string_blank "$P6_DFZ_CONTEXT_DISABLE"; then
+      local -a _context_lines=( ${=P6_DFZ_PROMPT_CONTEXT_LINES} )
+      for lf in $_context_lines; do p6df::core::prompt::runtime::line "$lf"; done
+    fi
+
+    if p6_string_blank "$P6_DFZ_SYSTEM_DISABLE"; then
+      local -a _system_lines=( ${=P6_DFZ_PROMPT_SYSTEM_LINES} )
+      for lf in $_system_lines; do p6df::core::prompt::runtime::line "$lf"; done
+    fi
+
+    if p6_string_blank "$P6_DFZ_ENV_DISABLE"; then
+      local -a _env_lines=( ${=P6_DFZ_PROMPT_ENV_LINES} )
+      for lf in $_env_lines; do p6df::core::prompt::runtime::line "$lf"; done
+    fi
+
+    if p6_string_blank "$P6_DFZ_MOD_DISABLE"; then
+      local -a _mod_lines=( ${=P6_DFZ_PROMPT_MOD_LINES} )
+      for lf in $_mod_lines; do p6df::core::prompt::runtime::line "$lf"; done
+    fi
+
   fi
 
-  for lf in $_other_lines; do
-    p6df::core::prompt::runtime::line "$lf"
-  done
+  if p6_string_blank "$P6_DFZ_BOTTOM_DISABLE"; then
+    local -a _bottom_lines=( ${=P6_DFZ_PROMPT_MOD_BOTTOM_LINES} )
+    for lf in $_bottom_lines; do p6df::core::prompt::runtime::line "$lf"; done
+  fi
 
   p6_time "$t1" "TOTAL: p6df::core::prompt::runtime"
 
@@ -114,8 +136,20 @@ p6df::core::prompt::runtime::line() {
     local func="$1"
 
     local t3=$EPOCHREALTIME
-    local cnt=$(p6_run_yield "$func")
+    local raw=$(p6_run_yield "$func")
     p6_time "$t3" "p6df::core::prompt::runtime: $func"
+
+    local cnt
+    if p6_string_blank_NOT "$raw"; then
+        local -a parts
+        parts=("${(z)raw}")
+        if [[ ${#parts} -ge 2 && "${parts[2]}" == \$* ]]; then
+            cnt=$(p6df::core::profile::default::mod "${parts[1]}" "${(@)parts[2,-1]}")
+        else
+            cnt="$raw"
+        fi
+    fi
+
     if p6_string_blank_NOT "$cnt"; then
         p6_return_str "$cnt"
     else
@@ -138,20 +172,36 @@ p6df::core::prompt::module::init() {
 
   # %repo
   p6df::core::module::parse "$module"
+  local prompt_init_func=$repo[prompt_init]
   local prompt_lang_func=$repo[prompt_lang]
+  local prompt_runtime_func=$repo[prompt_runtime]
+  local prompt_context_func=$repo[prompt_context]
+  local prompt_system_func=$repo[prompt_system]
   local prompt_env_func=$repo[prompt_env]
-  local prompt_mod_func=$repo[prompt_mod]
+  local profile_mod_func=$repo[profile_mod]
   local prompt_mod_bottom_func=$repo[prompt_mod_bottom]
   unset repo
 
+  if type -f "$prompt_init_func" >/dev/null 2>&1; then
+    p6_run_yield "$prompt_init_func"
+  fi
   if type -f "$prompt_lang_func" >/dev/null 2>&1; then
     p6df::core::prompt::line::add::lang "$prompt_lang_func"
+  fi
+  if type -f "$prompt_runtime_func" >/dev/null 2>&1; then
+    p6df::core::prompt::line::add::runtime "$prompt_runtime_func"
+  fi
+  if type -f "$prompt_context_func" >/dev/null 2>&1; then
+    p6df::core::prompt::line::add::context "$prompt_context_func"
+  fi
+  if type -f "$prompt_system_func" >/dev/null 2>&1; then
+    p6df::core::prompt::line::add::system "$prompt_system_func"
   fi
   if type -f "$prompt_env_func" >/dev/null 2>&1; then
     p6df::core::prompt::line::add::env "$prompt_env_func"
   fi
-  if type -f "$prompt_mod_func" >/dev/null 2>&1; then
-    p6df::core::prompt::line::add::mod "$prompt_mod_func"
+  if type -f "$profile_mod_func" >/dev/null 2>&1; then
+    p6df::core::prompt::line::add::mod "$profile_mod_func"
   fi
   if type -f "$prompt_mod_bottom_func" >/dev/null 2>&1; then
     p6df::core::prompt::line::add::mod::bottom "$prompt_mod_bottom_func"
@@ -175,6 +225,63 @@ p6df::core::prompt::line::add::lang() {
   local func="$1"
 
   p6_env_export P6_DFZ_PROMPT_LANG_LINES "${P6_DFZ_PROMPT_LANG_LINES:+$P6_DFZ_PROMPT_LANG_LINES }$func"
+
+  p6_return_void
+}
+
+######################################################################
+#<
+#
+# Function: p6df::core::prompt::line::add::runtime(func)
+#
+#  Args:
+#	func -
+#
+#  Environment:	 P6_DFZ_PROMPT_RUNTIME_LINES
+#>
+######################################################################
+p6df::core::prompt::line::add::runtime() {
+  local func="$1"
+
+  p6_env_export P6_DFZ_PROMPT_RUNTIME_LINES "${P6_DFZ_PROMPT_RUNTIME_LINES:+$P6_DFZ_PROMPT_RUNTIME_LINES }$func"
+
+  p6_return_void
+}
+
+######################################################################
+#<
+#
+# Function: p6df::core::prompt::line::add::context(func)
+#
+#  Args:
+#	func -
+#
+#  Environment:	 P6_DFZ_PROMPT_CONTEXT_LINES
+#>
+######################################################################
+p6df::core::prompt::line::add::context() {
+  local func="$1"
+
+  p6_env_export P6_DFZ_PROMPT_CONTEXT_LINES "${P6_DFZ_PROMPT_CONTEXT_LINES:+$P6_DFZ_PROMPT_CONTEXT_LINES }$func"
+
+  p6_return_void
+}
+
+######################################################################
+#<
+#
+# Function: p6df::core::prompt::line::add::system(func)
+#
+#  Args:
+#	func -
+#
+#  Environment:	 P6_DFZ_PROMPT_SYSTEM_LINES
+#>
+######################################################################
+p6df::core::prompt::line::add::system() {
+  local func="$1"
+
+  p6_env_export P6_DFZ_PROMPT_SYSTEM_LINES "${P6_DFZ_PROMPT_SYSTEM_LINES:+$P6_DFZ_PROMPT_SYSTEM_LINES }$func"
 
   p6_return_void
 }

--- a/lib/skills.zsh
+++ b/lib/skills.zsh
@@ -1,9 +1,7 @@
-# shellcheck shell=bash
-
 ######################################################################
 #<
 #
-# Function: p6df::core::completions::module::init(module, dir)
+# Function: p6df::core::skills::module::init(module, dir)
 #
 #  Args:
 #	module -
@@ -11,17 +9,17 @@
 #
 #>
 ######################################################################
-p6df::core::completions::module::init() {
+p6df::core::skills::module::init() {
   local module="$1"
   local dir="$2"
 
   # %repo
   p6df::core::module::parse "$module"
-  local completions_func=$repo[completion]
+  local skills_func=$repo[skills_init]
   unset repo
 
-  if type -f "$completions_func" >/dev/null 2>&1; then
-    p6_run_yield "$completions_func $module $dir"
+  if type -f "$skills_func" >/dev/null 2>&1; then
+    p6_run_yield "$skills_func $module $dir"
   fi
 
   p6_return_void


### PR DESCRIPTION
## What
Adds env, cdpath, fpath, langmgr module hook dispatch in the core module init pipeline; introduces bootstrap module init; expands `module::parse` with profile/prompt/skills keys; fixes a typo in completions (`copmletions_func`); documents new hooks and flow in docs.

## Why
The module init pipeline was missing several lifecycle hooks (env, cdpath, fpath, langmgr) needed by downstream modules. The prompt module parse table was incomplete, preventing profile::mod, profile::on/off, and other new hooks from being dispatched. The bootstrap step was previously inlined and needed to be extracted so modules loaded from `P6_DFZ_SRC_DIR` bootstrap correctly.

## Test plan
- Source p6df-core in a zsh session and verify no errors
- Confirm `p6df::core::module::init` calls each new hook in order
- Confirm `p6df::core::completions::module::init` resolves the correct function name (typo fix)

## Dependencies
None