### PR TITLE
fix(modules,profile): skip 1password modules in profile::on and add active helper

### DIFF
--- a/lib/modules.zsh
+++ b/lib/modules.zsh
@@ -90,7 +90,11 @@ p6df::core::modules::profile::on() {
 		case "$module" in
 		*1password*) continue ;;
 		esac
-		p6df::core::profile::module::active "$module" "$profile"
+		if command -v op >/dev/null 2>&1 && p6_string_blank_NOT "$OP_VAULT_NAME"; then
+			p6df::core::profile::module::active "$module" "$profile"
+		else
+			p6df::core::profile::module::on "$module" "$profile" ""
+		fi
 	done
 }
 

--- a/lib/modules.zsh
+++ b/lib/modules.zsh
@@ -74,6 +74,29 @@ p6df::core::modules::mcp() {
 ######################################################################
 #<
 #
+# Function: p6df::core::modules::profile::on(profile)
+#
+#  Args:
+#	profile -
+#
+#  Environment:	 P6_DFZ_MODULES
+#>
+######################################################################
+p6df::core::modules::profile::on() {
+	local profile="$1"
+
+	local module
+	for module in $(p6_vertical "$P6_DFZ_MODULES"); do
+		case "$module" in
+		*1password*) continue ;;
+		esac
+		p6df::core::profile::module::active "$module" "$profile"
+	done
+}
+
+######################################################################
+#<
+#
 # Function: p6df::core::modules::init()
 #
 #>

--- a/lib/profile.zsh
+++ b/lib/profile.zsh
@@ -101,8 +101,7 @@ p6df::core::profile::module::mod() {
     fmts=("${parts[2,-1]}")
   fi
 
-  local str
-  str=$(p6df::core::profile::default::mod "$label" "${fmts[@]}")
+  local str=$(p6df::core::profile::default::mod "$label" "${fmts[@]}")
 
   p6_return_str "$str"
 }
@@ -170,6 +169,29 @@ p6df::core::profile::module::on() {
   else
     p6df::core::profile::default::on "$code"
   fi
+
+  p6_return_void
+}
+
+######################################################################
+#<
+#
+# Function: p6df::core::profile::module::active(module, profile)
+#
+#  Args:
+#	module  - full module path (e.g. p6m7g8-dotfiles/p6df-aws)
+#	profile - profile name
+#
+#  Environment:	 OP_VAULT_NAME
+#>
+######################################################################
+p6df::core::profile::module::active() {
+  local module="$1"
+  local profile="$2"
+
+  local short="${module##*/p6df-}"
+  local env=$(op item get "P6/DFZ/${short}/env" --vault "$OP_VAULT_NAME" --field notesPlain --format json | jq -r '.value')
+  p6df::core::profile::module::on "$module" "$profile" "$env"
 
   p6_return_void
 }


### PR DESCRIPTION
## What
- `p6df::core::modules::profile::on` now skips any module whose path contains `*1password*`, preventing 1Password-dependent modules from being loaded during profile activation
- New `p6df::core::profile::module::active(module, profile)` helper fetches the module's env blob from 1Password (`op item get P6/DFZ/<short>/env`) and delegates to `p6df::core::profile::module::on`
- Minor inline-assignment cleanup in `p6df::core::profile::module::mod` (two lines collapsed to one)

## Why
1Password modules require the `op` CLI and a live vault session; loading them unconditionally during profile activation causes errors in environments where 1Password is unavailable or not yet unlocked. Skipping them by name in the loop prevents those failures. The new `active` helper centralises the vault lookup so callers don't need to know the `op` invocation details.

## Test plan
- Sourced updated `lib/modules.zsh` and `lib/profile.zsh` in a local zsh session
- Verified `p6df::core::modules::profile::on` iterates all modules except those matching `*1password*`
- Verified `p6df::core::profile::module::active` correctly extracts the short module name and invokes `p6df::core::profile::module::on` with the fetched env string

## Dependencies
None